### PR TITLE
Set JSON pretty printing

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -69,6 +69,7 @@ public class RepoSense {
             RepoConfiguration.setIsFindingPreviousAuthorsPerformedToRepoConfigs(configs,
                     cliArguments.isFindingPreviousAuthorsPerformed());
 
+
             if (RepoConfiguration.isAnyRepoFindingPreviousAuthors(configs)
                     && !GitVersion.isGitVersionSufficientForFindingPreviousAuthors()) {
                 logger.warning(FINDING_PREVIOUS_AUTHORS_INVALID_VERSION_WARNING_MESSAGE);
@@ -79,6 +80,10 @@ public class RepoSense {
             if (globalGitConfig.size() != 0) {
                 GitConfig.setGlobalGitLfsConfig(GitConfig.SKIP_SMUDGE_CONFIG_SETTINGS);
             }
+
+
+            FileUtil.setPrettierPrintingMode(cliArguments.getIsJsonPrettierUsed());
+
 
             ReportGenerator reportGenerator = new ReportGenerator();
             List<Path> reportFoldersAndFiles = reportGenerator.generateReposReport(configs,
@@ -92,6 +97,7 @@ public class RepoSense {
 
             FileUtil.zipFoldersAndFiles(reportFoldersAndFiles, cliArguments.getOutputFilePath().toAbsolutePath(),
                     ".json");
+            System.out.println(cliArguments.getIsJsonPrettierUsed());
 
             // Set back to user's initial global git lfs config
             GitConfig.setGlobalGitLfsConfig(globalGitConfig);

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -26,6 +26,7 @@ public class CliArguments {
     private final boolean isSinceDateProvided;
     private final boolean isUntilDateProvided;
     private final List<FileType> formats;
+    private final boolean isJsonPrettierUsed;
     private final boolean isLastModifiedDateIncluded;
     private final boolean isShallowCloningPerformed;
     private final boolean isAutomaticallyLaunching;
@@ -37,6 +38,7 @@ public class CliArguments {
     private final boolean isFindingPreviousAuthorsPerformed;
     private boolean isTestMode = ArgsParser.DEFAULT_IS_TEST_MODE;
     private boolean isFreshClonePerformed = ArgsParser.DEFAULT_SHOULD_FRESH_CLONE;
+
 
 
     private List<String> locations;
@@ -79,6 +81,11 @@ public class CliArguments {
         this.groupConfigFilePath = builder.groupConfigFilePath;
         this.reportConfigFilePath = builder.reportConfigFilePath;
         this.reportConfiguration = builder.reportConfiguration;
+        this.isJsonPrettierUsed = builder.isJsonPrettierUsed;
+    }
+
+    public boolean getIsJsonPrettierUsed() {
+        return isJsonPrettierUsed;
     }
 
     public ZoneId getZoneId() {
@@ -226,7 +233,8 @@ public class CliArguments {
                 && Objects.equals(this.repoConfigFilePath, otherCliArguments.repoConfigFilePath)
                 && Objects.equals(this.authorConfigFilePath, otherCliArguments.authorConfigFilePath)
                 && Objects.equals(this.groupConfigFilePath, otherCliArguments.groupConfigFilePath)
-                && Objects.equals(this.reportConfigFilePath, otherCliArguments.reportConfigFilePath);
+                && Objects.equals(this.reportConfigFilePath, otherCliArguments.reportConfigFilePath)
+                && Objects.equals(this.isJsonPrettierUsed, otherCliArguments.isJsonPrettierUsed);
     }
 
     /**
@@ -260,6 +268,8 @@ public class CliArguments {
         private Path groupConfigFilePath;
         private Path reportConfigFilePath;
         private ReportConfiguration reportConfiguration;
+
+        private boolean isJsonPrettierUsed;
 
         public Builder() {
         }
@@ -385,6 +395,17 @@ public class CliArguments {
         }
 
         /**
+         * Checks if JSON is formatted to be prettier.
+         *
+         * @param isJsonPrettierUsed the boolean if json is supposed to be prettier
+         * @return the builder with jsonPrettierUsed set
+         */
+        public Builder isJsonPrettierUsed(boolean isJsonPrettierUsed) {
+            this.isJsonPrettierUsed = isJsonPrettierUsed;
+            return this;
+        }
+
+        /**
          * Adds the {@code numCloningThreads} to CliArguments.
          *
          * @param numCloningThreads The number of cloning threads.
@@ -453,6 +474,7 @@ public class CliArguments {
             this.locations = locations;
             return this;
         }
+
 
         /**
          * Adds the {@code isViewModeOnly} to CliArguments.

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -58,6 +58,7 @@ public class ArgsParser {
     public static final String[] VERSION_FLAGS = new String[] {"--version", "-V"};
     public static final String[] LAST_MODIFIED_DATE_FLAGS = new String[] {"--last-modified-date", "-l"};
     public static final String[] FIND_PREVIOUS_AUTHORS_FLAGS = new String[] {"--find-previous-authors", "-F"};
+    public static final String[] JSON_PRINT_MODE_FLAGS = new String[] {"--use-json-prettier-printing", "-j"};
 
     public static final String[] CLONING_THREADS_FLAG = new String[] {"--cloning-threads"};
     public static final String[] ANALYSIS_THREADS_FLAG = new String[] {"--analysis-threads"};
@@ -105,6 +106,12 @@ public class ArgsParser {
                 .addArgumentGroup(MESSAGE_HEADER_TESTING);
 
         // Boolean flags
+
+        parser.addArgument(JSON_PRINT_MODE_FLAGS)
+                .dest(JSON_PRINT_MODE_FLAGS[0])
+                .action(Arguments.storeTrue())
+                .help("A flag to make the JSON print prettier.");
+
         parser.addArgument(HELP_FLAGS)
                 .help("Show help message.")
                 .action(new HelpArgumentAction());
@@ -278,6 +285,8 @@ public class ArgsParser {
             int numCloningThreads = results.get(CLONING_THREADS_FLAG[0]);
             int numAnalysisThreads = results.get(ANALYSIS_THREADS_FLAG[0]);
 
+            boolean isJsonPrettierUsed = results.get(JSON_PRINT_MODE_FLAGS[0]);
+
             CliArguments.Builder cliArgumentsBuilder = new CliArguments.Builder()
                     .configFolderPath(configFolderPath)
                     .reportDirectoryPath(reportFolderPath)
@@ -293,7 +302,8 @@ public class ArgsParser {
                     .isFindingPreviousAuthorsPerformed(shouldFindPreviousAuthors)
                     .numCloningThreads(numCloningThreads)
                     .numAnalysisThreads(numAnalysisThreads)
-                    .isTestMode(isTestMode);
+                    .isTestMode(isTestMode)
+                    .isJsonPrettierUsed(isJsonPrettierUsed);
 
             LogsManager.setLogFolderLocation(outputFolderPath);
 

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -61,6 +61,8 @@ public class FileUtil {
     private static final String MESSAGE_FAIL_TO_COPY_ASSETS =
             "Exception occurred while attempting to copy custom assets.";
 
+    private static boolean isPrettierPrintingUsed = false;
+
     /**
      * Zips all files of type {@code fileTypes} that are in the directory {@code pathsToZip} into a single file and
      * output it to {@code sourceAndOutputPath}.
@@ -68,6 +70,7 @@ public class FileUtil {
     public static void zipFoldersAndFiles(List<Path> pathsToZip, Path sourceAndOutputPath, String... fileTypes) {
         zipFoldersAndFiles(pathsToZip, sourceAndOutputPath, sourceAndOutputPath, fileTypes);
     }
+
 
     /**
      * Zips all files listed in {@code pathsToZip} of type {@code fileTypes} located in the directory
@@ -96,6 +99,16 @@ public class FileUtil {
         }
     }
 
+
+    /**
+     * Sets the printing mode if it is prettier or not.
+     *
+     * @param isPrettierPrinting boolean if prettier printing is used or not
+     */
+    public static void setPrettierPrintingMode(boolean isPrettierPrinting) {
+        isPrettierPrintingUsed = isPrettierPrinting;
+    }
+
     /**
      * Writes the JSON file representing the {@code object} at the given {@code path}.
      *
@@ -103,16 +116,23 @@ public class FileUtil {
      * was an error while writing the JSON file.
      */
     public static Optional<Path> writeJsonFile(Object object, String path) {
-        Gson gson = new GsonBuilder()
+        GsonBuilder gsonBuilder = new GsonBuilder()
                 .registerTypeAdapter(LocalDateTime.class, (JsonSerializer<LocalDateTime>) (date, typeOfSrc, context)
                         -> new JsonPrimitive(date.format(DateTimeFormatter.ofPattern(GITHUB_API_DATE_FORMAT))))
                 .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
                 .registerTypeAdapter(ZoneId.class, (JsonSerializer<ZoneId>) (zoneId, typeOfSrc, context)
-                        -> new JsonPrimitive(zoneId.toString()))
-                .create();
+                        -> new JsonPrimitive(zoneId.toString()));
 
         // Gson serializer from:
         // https://stackoverflow.com/questions/39192945/serialize-java-8-localdate-as-yyyy-mm-dd-with-gson
+
+        Gson gson;
+        if (isPrettierPrintingUsed) {
+            gson = gsonBuilder.setPrettyPrinting().create();
+        } else {
+            gson = gsonBuilder.create();
+
+        }
 
         String result = gson.toJson(object);
 


### PR DESCRIPTION
My attempt on the hands-on practice.
```
Currently the JSON files generated are all one-liners. If the pretty printing JSON flag is used, then the JSON files will be prettier.

Added a feature that allows the person to generate prettier JSON files for better readability
```

