### PR TITLE
Allow period to parse by year

### DIFF
--- a/src/main/java/reposense/parser/PeriodArgumentType.java
+++ b/src/main/java/reposense/parser/PeriodArgumentType.java
@@ -19,7 +19,16 @@ public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
             "Invalid format. Period must be greater than 0.";
     private static final String PARSE_EXCEPTION_MESSAGE_NUMBER_TOO_LARGE =
             "Invalid format. Input number may be too large.";
-    private static final Pattern PERIOD_PATTERN = Pattern.compile("[0-9]+[dw]");
+    private static final Pattern PERIOD_PATTERN = Pattern.compile("[0-9]+[dwy]");
+
+    private static final String DAY_IDENTIFIER = "d";
+    private static final String WEEK_IDENTIFIER = "w";
+    private static final String YEAR_IDENTIFIER = "y";
+
+    private static final int NUMBER_OF_DAYS_IN_A_DAY = 1;
+    private static final int NUMBER_OF_DAYS_IN_A_WEEK = 7;
+    private static final int NUMBER_OF_DAYS_IN_A_YEAR = 365;
+
 
     @Override
     public Optional<Integer> convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
@@ -40,7 +49,23 @@ public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
             throw new ParseException(String.format(PARSE_EXCEPTION_MESSAGE_NOT_IN_NUMERIC, period));
         }
 
-        int multiplier = period.substring(period.length() - 1).equals("d") ? 1 : 7;
+        String isDateWeekOrYear = period.substring(period.length() - 1);
+        int multiplier = 0;
+        switch (isDateWeekOrYear) {
+        case (DAY_IDENTIFIER):
+            multiplier = NUMBER_OF_DAYS_IN_A_DAY;
+            break;
+        case (WEEK_IDENTIFIER):
+            multiplier = NUMBER_OF_DAYS_IN_A_WEEK;
+            break;
+        case (YEAR_IDENTIFIER):
+            multiplier = NUMBER_OF_DAYS_IN_A_YEAR;
+            break;
+        default:
+            // should not reach here
+            break;
+
+        }
 
         try {
             int convertedValue = Integer.parseInt(period.substring(0, period.length() - 1)) * multiplier;

--- a/src/main/java/reposense/parser/PeriodArgumentType.java
+++ b/src/main/java/reposense/parser/PeriodArgumentType.java
@@ -46,23 +46,24 @@ public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
      * Parses a {@code isDateWeekOrYear} String and returns an {@link Integer} representing the multiplier for the
      * type of period.
      *
+     * @throws ParseException if period identifier is invalid.
      */
     private static int getMultiplier(String isDateWeekOrYear) throws ParseException {
         int multiplier;
         switch (isDateWeekOrYear) {
-            case (DAY_IDENTIFIER):
-                multiplier = NUMBER_OF_DAYS_IN_A_DAY;
-                break;
-            case (WEEK_IDENTIFIER):
-                multiplier = NUMBER_OF_DAYS_IN_A_WEEK;
-                break;
-            case (YEAR_IDENTIFIER):
-                multiplier = NUMBER_OF_DAYS_IN_A_YEAR;
-                break;
-            default:
-                // should not reach here
-                throw new ParseException(String.format(PARSE_EXCEPTION_MESSAGE_NUMBER_UNRECOGNISED_IDENTIFIER,
-                        isDateWeekOrYear));
+        case (DAY_IDENTIFIER):
+            multiplier = NUMBER_OF_DAYS_IN_A_DAY;
+            break;
+        case (WEEK_IDENTIFIER):
+            multiplier = NUMBER_OF_DAYS_IN_A_WEEK;
+            break;
+        case (YEAR_IDENTIFIER):
+            multiplier = NUMBER_OF_DAYS_IN_A_YEAR;
+            break;
+        default:
+            // should not reach here
+            throw new ParseException(String.format(PARSE_EXCEPTION_MESSAGE_NUMBER_UNRECOGNISED_IDENTIFIER,
+                    isDateWeekOrYear));
         }
         return multiplier;
     }

--- a/src/main/java/reposense/parser/PeriodArgumentType.java
+++ b/src/main/java/reposense/parser/PeriodArgumentType.java
@@ -19,6 +19,9 @@ public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
             "Invalid format. Period must be greater than 0.";
     private static final String PARSE_EXCEPTION_MESSAGE_NUMBER_TOO_LARGE =
             "Invalid format. Input number may be too large.";
+
+    private static final String PARSE_EXCEPTION_MESSAGE_NUMBER_UNRECOGNISED_IDENTIFIER =
+            "Invalid format. Unrecognised indentifier.";
     private static final Pattern PERIOD_PATTERN = Pattern.compile("[0-9]+[dwy]");
 
     private static final String DAY_IDENTIFIER = "d";
@@ -40,6 +43,31 @@ public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
     }
 
     /**
+     * Parses a {@code isDateWeekOrYear} String and returns an {@link Integer} representing the multiplier for the
+     * type of period.
+     *
+     */
+    private static int getMultiplier(String isDateWeekOrYear) throws ParseException {
+        int multiplier;
+        switch (isDateWeekOrYear) {
+            case (DAY_IDENTIFIER):
+                multiplier = NUMBER_OF_DAYS_IN_A_DAY;
+                break;
+            case (WEEK_IDENTIFIER):
+                multiplier = NUMBER_OF_DAYS_IN_A_WEEK;
+                break;
+            case (YEAR_IDENTIFIER):
+                multiplier = NUMBER_OF_DAYS_IN_A_YEAR;
+                break;
+            default:
+                // should not reach here
+                throw new ParseException(String.format(PARSE_EXCEPTION_MESSAGE_NUMBER_UNRECOGNISED_IDENTIFIER,
+                        isDateWeekOrYear));
+        }
+        return multiplier;
+    }
+
+    /**
      * Parses a {@code period} String and returns an {@link Integer} representing the number of days.
      *
      * @throws ParseException if period format or number is invalid.
@@ -50,22 +78,7 @@ public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
         }
 
         String isDateWeekOrYear = period.substring(period.length() - 1);
-        int multiplier = 0;
-        switch (isDateWeekOrYear) {
-        case (DAY_IDENTIFIER):
-            multiplier = NUMBER_OF_DAYS_IN_A_DAY;
-            break;
-        case (WEEK_IDENTIFIER):
-            multiplier = NUMBER_OF_DAYS_IN_A_WEEK;
-            break;
-        case (YEAR_IDENTIFIER):
-            multiplier = NUMBER_OF_DAYS_IN_A_YEAR;
-            break;
-        default:
-            // should not reach here
-            break;
-
-        }
+        int multiplier = getMultiplier(isDateWeekOrYear);
 
         try {
             int convertedValue = Integer.parseInt(period.substring(0, period.length() - 1)) * multiplier;

--- a/src/main/java/reposense/parser/PeriodArgumentType.java
+++ b/src/main/java/reposense/parser/PeriodArgumentType.java
@@ -13,7 +13,7 @@ import net.sourceforge.argparse4j.inf.ArgumentType;
  */
 public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
     private static final String PARSE_EXCEPTION_MESSAGE_NOT_IN_NUMERIC =
-            "Invalid format. Period must be in the format of nd (n days) or nw (n weeks), "
+            "Invalid format. Period must be in the format of nd (n days) or nw (n weeks) or ny (n years), "
             + "where n is a number greater than 0.";
     private static final String PARSE_EXCEPTION_MESSAGE_SMALLER_THAN_ZERO =
             "Invalid format. Period must be greater than 0.";


### PR DESCRIPTION
```
When using the `--period` flag, it can only parse by days and weeks. 
However, if one wants to look at a longer period, they might have to manually convert the period 
into days and weeks, which is very troublesome. 

Hence, I added the extra functionality of parsing by years so it 
accepts arguments such as '2y' to signify a period of 2 years.
```
